### PR TITLE
Added ability to configure mysqldump command

### DIFF
--- a/backup_mysql_database.sh
+++ b/backup_mysql_database.sh
@@ -69,7 +69,7 @@ function main {
     deleteIfExists ${COMPRESSED_BACKUP_FILENAME}
 
     log "Starting backup of database: $DATABASE_NAME data to compressed file: $COMPRESSED_BACKUP_FILENAME"
-    { nice -19 cat <(echo "SET FOREIGN_KEY_CHECKS=0;") <(mysqldump \
+    { nice -19 cat <(echo "SET FOREIGN_KEY_CHECKS=0;") <(${MYSQL_DUMP:-mysqldump} \
 	--opt \
 	--comments=0 \
 	--compress \

--- a/mysql.sh
+++ b/mysql.sh
@@ -32,6 +32,7 @@ SERVER_2["MYSQL_PASSWORD"]=password
 SERVER_2["MYSQL_PORT"]=3307
 SERVER_2["INCLUDE"]="events"
 SERVER_2["EXCLUDE"]=""
+SERVER_2["MYSQL_DUMP"]="ssh user@example.com mysqldump" # Example of ssh tunnelling
 
 if [ "$#" != "2" ]; then
     echo "Error: expects two argument: server_id, ( user | host | password | port )" 1>&2
@@ -46,6 +47,7 @@ MYSQL_PASSWORD="$SERVER_PTR[MYSQL_PASSWORD]"
 MYSQL_PORT="$SERVER_PTR[MYSQL_PORT]"
 MYSQL_INCLUDE="$SERVER_PTR[INCLUDE]"
 MYSQL_EXCLUDE="$SERVER_PTR[EXCLUDE]"
+MYSQL_DUMP="$SERVER_PTR[MYSQL_DUMP]"
 
 # Ensure that the server definition exists by validating that it doesn't return empty
 SERVER_EXISTS="$SERVER_PTR[@]"

--- a/mysql.sh
+++ b/mysql.sh
@@ -32,7 +32,7 @@ SERVER_2["MYSQL_PASSWORD"]=password
 SERVER_2["MYSQL_PORT"]=3307
 SERVER_2["INCLUDE"]="events"
 SERVER_2["EXCLUDE"]=""
-SERVER_2["MYSQL_DUMP"]="ssh user@example.com mysqldump" # Example of ssh tunnelling
+SERVER_2["MYSQL_DUMP"]="ssh -o 'BatchMode yes' user@example.com mysqldump" # Example of ssh tunnelling
 
 if [ "$#" != "2" ]; then
     echo "Error: expects two argument: server_id, ( user | host | password | port )" 1>&2


### PR DESCRIPTION
Due to an environment with a zoning firewall, we have a need to implement the ability to tunnel the mysqldump of the database being backed up through SSH.  I figured the easiest way of implementing this feature was to allow the mysqldump command to be configurable for each host/database.